### PR TITLE
Merge timeseries modules in the remote sensing stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,10 @@
-# RS Images
+# TS-RS Images
 
-Repository based on Mambaforge image to create Apptainer containers for CPU-only nodes, aiming Remote Sensing workflows.
+BranchRepository based Timeseries + Remote Sensing workflows
 
-Released builds available at Docker Hub: https://hub.docker.com/repository/docker/ricardobarroslourenco/mambaforge_custom_geo_cpuonly/
-
+Released builds available at Docker Hub: https://hub.docker.com/repository/docker/ricardobarroslourenco/ts_rs/general
 # Change Log
 Major updates here. For details, see the commit log.
 
-## v0.3 and v0.3.1
-- Adds pingouin
-- v0.3.1 in dockerhub is the same as v0.3, just fixing a building error.
-
-## v0.2 
-- Adds Cartopy offline bases (for HPC usage)
-### v0.2.2
-- Fix issue of creating a new conda env (instead, will be updating the base env)
-
-### v0.2.3
-- Fix issue on conda envs
-- Adds Fiona (to allow clipping)
-
-### v0.2.4
-- Adds PROJ binaries (try to fix fiona error when importing)
-
 ## v0.1 
-- Initial release based in a mambaforge image plus some Xarray + Dask for CPU
+- Initial release based in `main` branch version 0.3.1, plus timeseries analysis with interpretMl

--- a/base.yml
+++ b/base.yml
@@ -40,8 +40,9 @@ dependencies:
   - pingouin
   - pandas
   - seaborn
-  - shap
+  - shap == 0.41.0
   - scikit-learn
-  - interpret==0.4.2
+  - interpret == 0.4.2
   - xgboost
+  - numpy < 1.24.0
 prefix: /opt/conda

--- a/base.yml
+++ b/base.yml
@@ -38,4 +38,10 @@ dependencies:
   - fiona
   - proj
   - pingouin
+  - pandas
+  - seaborn
+  - shap
+  - scikit-learn
+  - interpret
+  - xgboost
 prefix: /opt/conda

--- a/base.yml
+++ b/base.yml
@@ -42,6 +42,6 @@ dependencies:
   - seaborn
   - shap
   - scikit-learn
-  - interpret
+  - interpret==0.4.2
   - xgboost
 prefix: /opt/conda


### PR DESCRIPTION
In general works (done testing with the interpretml modules and shap). `numpy`, `shap` and `interpret` had their versions fixed due to issues found when merging (refer to: https://github.com/ricardobarroslourenco/SOS_Flux_Modelling/issues/2 ). Pending flexibilization when upgrading future package versions.